### PR TITLE
Fixed version value in gt4_word_map_new call

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -19,9 +19,12 @@ LISTMAKER_SOURCES = \
 	sequence-source.c sequence-source.h \
 	sequence-stream.c sequence-stream.h \
 	sequence-zstream.c sequence-zstream.h \
+	set-operations.c set-operations.h \
 	common.c common.h \
 	utils.c utils.h \
-	word-array-sorted.c word-array-sorted.h
+	word-array-sorted.c word-array-sorted.h \
+	word-list.c word-list.h \
+	word-list-stream.c word-list-stream.h
 
 LISTMAKER2_SOURCES = \
 	glistmaker2.c \
@@ -56,6 +59,7 @@ LISTQUERY_SOURCES = \
 	common.c common.h \
 	queue.c queue.h \
 	utils.c utils.h \
+	word-list.c word-list.h \
 	word-array-sorted.c word-array-sorted.h
 
 LISTCOMPARE_SOURCES = \
@@ -75,6 +79,7 @@ LISTCOMPARE_SOURCES = \
 	queue.c queue.h \
 	utils.c \
 	word-array-sorted.c word-array-sorted.h \
+	word-list.c word-list.h \
 	word-list-stream.c word-list-stream.h
 
 GMER_COUNTER_SOURCES = \
@@ -82,7 +87,6 @@ GMER_COUNTER_SOURCES = \
 	index.c index.h \
 	listmaker-queue.c listmaker-queue.h \
 	trie.c trie.h \
-	word-map.c word-map.h \
 	sequence.c sequence.h \
 	sequence-block.c sequence-block.h \
 	sequence-file.c sequence-file.h \
@@ -94,7 +98,7 @@ GMER_COUNTER_SOURCES = \
 	thread-pool.c thread-pool.h \
 	queue.c queue.h \
 	utils.c utils.h \
-	word-array-sorted.c word-array-sorted.h \
+	word-list.c word-list.h \
 	database.c database.h
 
 GMER_CALLER_SOURCES = \
@@ -113,11 +117,11 @@ GASSEMBLER_SOURCES = \
 	matrix.c matrix.h \
 	queue.c queue.h \
 	sequence.c sequence.h \
+	sequence-block.c sequence-block.h \
 	sequence-file.c sequence-file.h \
+	sequence-source.c sequence-source.h \
 	trie.c trie.h \
 	utils.c utils.h \
-	word-map.c word-map.h \
-	wordtable.c wordtable.h \
 	gassembler.c
 
 DISTRO_SOURCES = \
@@ -184,8 +188,8 @@ gmer_counter: $(GMER_COUNTER_SOURCES) $(AZ_SOURCES) $(ARIKKEI_SOURCES)
 gmer_caller: $(GMER_CALLER_SOURCES)
 	$(CXX) $(GMER_CALLER_SOURCES) -o gmer_caller $(LIBS) $(CXXFLAGS) -Wall
 
-gassembler: $(GASSEMBLER_SOURCES)
-	$(CXX) $(GASSEMBLER_SOURCES) -o gassembler $(LIBS) $(CXXFLAGS) -Wall
+gassembler: $(GASSEMBLER_SOURCES) $(AZ_SOURCES) $(ARIKKEI_SOURCES)
+	$(CXX) $(GASSEMBLER_SOURCES) $(AZ_SOURCES) $(ARIKKEI_SOURCES) -o gassembler $(LIBS) $(CXXFLAGS) $(AZ_FLAGS)
 
 distro: $(DISTRO_SOURCES)
 	$(CXX) $(DISTRO_SOURCES) -o distro $(LIBS) $(CXXFLAGS) -Wall

--- a/src/glistcompare.c
+++ b/src/glistcompare.c
@@ -279,7 +279,7 @@ int main (int argc, const char *argv[])
     GT4WordMap *map1, *map2;
     int cinf;
     map1 = gt4_word_map_new (fnames[0], VERSION_MAJOR, USE_SCOUTS);
-    map2 = gt4_word_map_new (fnames[1], VERSION_MINOR, USE_SCOUTS);
+    map2 = gt4_word_map_new (fnames[1], VERSION_MAJOR, USE_SCOUTS);
     if (!map1 || !map2) {
       fprintf (stderr, "Error: Creating the wordmap failed!\n");
       exit (1);

--- a/src/glistcompare.c
+++ b/src/glistcompare.c
@@ -616,7 +616,7 @@ union_multi (AZObject *m[], unsigned int nmaps, unsigned int cutoff, int ofile, 
   header->wordlength = insts[0]->word_length;
   header->nwords = 0;
   header->totalfreq = 0;
-  header->padding = sizeof (GT4ListHeader);
+  header->list_start = sizeof (GT4ListHeader);
 
   t_s = get_time ();
 

--- a/src/listmaker-queue.c
+++ b/src/listmaker-queue.c
@@ -68,8 +68,12 @@ listmaker_queue_init (GT4ListMakerQueueClass *klass, GT4ListMakerQueue *mq)
 static void
 listmaker_queue_finalize (GT4ListMakerQueueClass *klass, GT4ListMakerQueue *mq)
 {
+  unsigned int i;
   free (mq->free_s_tables);
   free (mq->used_s_tables);
+  for (i = 0; i < mq->n_tmp_files; i++) {
+    free (mq->tmp_files[i]);
+  }
 }
 
 void
@@ -152,93 +156,6 @@ maker_queue_add_file (GT4ListMakerQueue *mq, const char *filename, unsigned int 
   }
 }
 
-wordtable *
-queue_get_smallest_table (GT4ListMakerQueue *queue)
-{
-	unsigned int i, min;
-	unsigned long long minslots;
-	wordtable *t;
-	min = 0;
-	minslots = queue->available[0]->nwordslots;
-	for (i = 1; i < queue->navailable; i++) {
-		if (queue->available[i]->nwordslots < minslots) {
-			min = i;
-			minslots = queue->available[i]->nwordslots;
-		}
-	}
-	t = queue->available[min];
-	queue->available[min] = queue->available[queue->navailable - 1];
-	queue->navailable -= 1;
-	return t;
-}
-
-wordtable *
-queue_get_largest_table (GT4ListMakerQueue *queue)
-{
-	unsigned int i, max;
-	unsigned long long maxslots;
-	wordtable *t;
-	max = 0;
-	maxslots = queue->available[0]->nwordslots;
-	for (i = 1; i < queue->navailable; i++) {
-		if (queue->available[i]->nwordslots > maxslots) {
-			max = i;
-			maxslots = queue->available[i]->nwordslots;
-		}
-	}
-	t = queue->available[max];
-	queue->available[max] = queue->available[queue->navailable - 1];
-	queue->navailable -= 1;
-	return t;
-}
-
-wordtable *
-queue_get_sorted (GT4ListMakerQueue *queue)
-{
-	queue->nsorted -= 1;
-	return queue->sorted[queue->nsorted];
-}
-
-wordtable *
-queue_get_smallest_sorted (GT4ListMakerQueue *queue)
-{
-	unsigned int i, min;
-	unsigned long long minwords;
-	wordtable *t;
-	min = 0;
-	minwords = queue->sorted[0]->nwords;
-	for (i = 1; i < queue->nsorted; i++) {
-		if (queue->sorted[i]->nwords < minwords) {
-			min = i;
-			minwords = queue->sorted[i]->nwords;
-		}
-	}
-	t = queue->sorted[min];
-	queue->sorted[min] = queue->sorted[queue->nsorted - 1];
-	queue->nsorted -= 1;
-	return t;
-}
-
-wordtable *
-queue_get_mostavailable_sorted (GT4ListMakerQueue *queue)
-{
-	unsigned int i, max;
-	unsigned long long maxavail;
-	wordtable *t;
-	max = 0;
-	maxavail = queue->sorted[0]->nwordslots - queue->sorted[0]->nwords;
-	for (i = 1; i < queue->nsorted; i++) {
-		if ((queue->sorted[i]->nwordslots - queue->sorted[0]->nwords) > maxavail) {
-			max = i;
-			maxavail = queue->sorted[i]->nwordslots - queue->sorted[i]->nwords;
-		}
-	}
-	t = queue->sorted[max];
-	queue->sorted[max] = queue->sorted[queue->nsorted - 1];
-	queue->nsorted -= 1;
-	return t;
-}
-
 static unsigned int finish = 0;
 
 static void *
@@ -298,20 +215,43 @@ task_read_delete (TaskRead *tr)
   free (tr);
 }
 
-TaskCollate *
-task_collate_new (GT4ListMakerQueue *mq, unsigned int max_tables)
+TaskCollateTables *
+task_collate_tables_new (GT4ListMakerQueue *mq, unsigned int max_tables)
 {
-  TaskCollate *tc;
-  tc = (TaskCollate *) malloc (sizeof (TaskCollate) + (max_tables - 1) * sizeof (wordtable *));
-  memset (tc, 0, sizeof (TaskCollate));
+  TaskCollateTables *tc;
+  tc = (TaskCollateTables *) malloc (sizeof (TaskCollateTables) + (max_tables - 1) * sizeof (wordtable *));
+  memset (tc, 0, sizeof (TaskCollateTables));
   tc->task.queue = &mq->queue;
-  tc->task.type = TASK_COLLATE;
+  tc->task.type = TASK_COLLATE_TABLES;
+  tc->task.priority = 9;
   return tc;
 }
 
 void
-task_collate_delete (TaskCollate *tc)
+task_collate_tables_delete (TaskCollateTables *tc)
 {
+  free (tc);
+}
+
+TaskCollateFiles *
+task_collate_files_new (GT4ListMakerQueue *mq, unsigned int max_files)
+{
+  TaskCollateFiles *tc;
+  tc = (TaskCollateFiles *) malloc (sizeof (TaskCollateFiles) + (max_files - 1) * sizeof (char *));
+  memset (tc, 0, sizeof (TaskCollateFiles));
+  tc->task.queue = &mq->queue;
+  tc->task.type = TASK_COLLATE_FILES;
+  tc->task.priority = 8;
+  return tc;
+}
+
+void
+task_collate_files_delete (TaskCollateFiles *tc)
+{
+  unsigned int i;
+  for (i = 0; i < tc->n_files; i++) {
+    free (tc->files[i]);
+  }
   free (tc);
 }
 

--- a/src/set-operations.c
+++ b/src/set-operations.c
@@ -1,0 +1,134 @@
+#define __GT4_SET_OPERATIONS_C__
+
+/*
+ * GenomeTester4
+ *
+ * A toolkit for creating and manipulating k-mer lists from biological sequences
+ * 
+ * Copyright (C) 2014-2018 University of Tartu
+ *
+ * Authors: Maarja Lepamets and Lauris Kaplinski
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+static unsigned int debug = 1;
+
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <libarikkei/arikkei-utils.h>
+
+#include "utils.h"
+#include "version.h"
+
+#include "set-operations.h"
+
+#define TMP_BUF_SIZE (12 * 1024)
+
+unsigned int
+gt4_write_union (AZObject *arrays[], unsigned int n_arrays, unsigned int cutoff, int ofile, GT4ListHeader *header)
+{
+  GT4WordSArrayImplementation *impls[GT4_MAX_SETS];
+  GT4WordSArrayInstance *insts[GT4_MAX_SETS];
+  unsigned int n_sources;
+  unsigned int j;
+  unsigned long long word;
+  unsigned char b[TMP_BUF_SIZE];
+  unsigned int bp = 0;
+  unsigned long long total = 0;
+  double t_s, t_e;
+
+  arikkei_return_val_if_fail (n_arrays <= GT4_MAX_SETS, 1);
+  
+  n_sources = 0;
+  for (j = 0; j < n_arrays; j++) {
+    impls[n_sources] = (GT4WordSArrayImplementation *) az_object_get_interface (AZ_OBJECT(arrays[j]), GT4_TYPE_WORD_SARRAY, (void **) &insts[n_sources]);
+    if (insts[n_sources]->num_words) {
+      gt4_word_sarray_get_first_word (impls[n_sources], insts[n_sources]);
+      total += insts[n_sources]->num_words;
+      n_sources += 1;
+    }
+  }
+
+  header->code = GT4_LIST_CODE;
+  header->version_major = VERSION_MAJOR;
+  header->version_minor = VERSION_MINOR;
+  header->wordlength = insts[0]->word_length;
+  header->nwords = 0;
+  header->totalfreq = 0;
+  header->list_start = sizeof (GT4ListHeader);
+
+  t_s = get_time ();
+
+  if (ofile) write (ofile, header, sizeof (GT4ListHeader));
+
+  word = 0xffffffffffffffff;
+  for (j = 0; j < n_sources; j++) {
+    if (insts[j]->word < word) word = insts[j]->word;
+  }
+    
+  while (n_sources) {
+    unsigned long long next = 0xffffffffffffffff;
+    unsigned int freq = 0;
+    j = 0;
+    while (j < n_sources) {
+      if (insts[j]->word == word) {
+        freq += insts[j]->count;
+        if (!gt4_word_sarray_get_next_word (impls[j], insts[j])) {
+          n_sources -= 1;
+          if (n_sources > 0) {
+            impls[j] = impls[n_sources];
+            insts[j] = insts[n_sources];
+            continue;
+          } else {
+            break;
+          }
+        }
+      }
+      if (insts[j]->word < next) next = insts[j]->word;
+      j += 1;
+    }
+    
+    /* Now we have word and freq */
+    if (freq >= cutoff) {
+      if (ofile) {
+        memcpy (&b[bp], &word, 8);
+        memcpy (&b[bp + 8], &freq, 4);
+        bp += 12;
+        if (bp >= TMP_BUF_SIZE) {
+          write (ofile, b, bp);
+          bp = 0;
+        }
+      }
+      header->nwords += 1;
+      header->totalfreq += freq;
+      if (debug && !(header->nwords % 100000000)) {
+        fprintf (stderr, "Words written: %uM\n", (unsigned int) (header->nwords / 1000000));
+      }
+    }
+    word = next;
+  }
+  if (ofile) {
+    if (bp) write (ofile, b, bp);
+    pwrite (ofile, header, sizeof (GT4ListHeader), 0);
+  }
+  t_e = get_time ();
+
+  if (debug > 0) {
+    fprintf (stderr, "Combined %u arrays: input %llu (%.3f Mwords/s) output %llu (%.3f Mwords/s)\n", n_arrays, total, total / (1000000 * (t_e - t_s)), header->nwords, header->nwords / (1000000 * (t_e - t_s)));
+  }
+  
+  return 0;
+}

--- a/src/set-operations.h
+++ b/src/set-operations.h
@@ -1,0 +1,36 @@
+#ifndef __GT4_SET_OPERATIONS_H__
+#define __GT4_SET_OPERATIONS_H__
+
+/*
+ * GenomeTester4
+ *
+ * A toolkit for creating and manipulating k-mer lists from biological sequences
+ * 
+ * Copyright (C) 2014-2018 University of Tartu
+ *
+ * Authors: Maarja Lepamets and Lauris Kaplinski
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "word-map.h"
+
+#define GT4_MAX_SETS 4096
+
+/* Combines N lists into one union, returns 0 on success */
+/* Arrays have to be AZObjects implementing GT4SortedWArray interface */
+
+unsigned int gt4_write_union (AZObject *arrays[], unsigned int n_arrays, unsigned int cutoff, int ofile, GT4ListHeader *header);
+
+#endif

--- a/src/utils.c
+++ b/src/utils.c
@@ -21,6 +21,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/mman.h>
@@ -39,16 +40,19 @@ gt4_mmap (const char *filename, unsigned long long *size)
 
 	status = stat (filename, &st);
 	if (status < 0) {
+	  fprintf (stderr, "Stat result %d\n", status);
 		return NULL;
 	}
 
 	handle = open (filename, O_RDONLY);
 	if (handle < 0) {
+	  fprintf (stderr, "Handle %d\n", handle);
 		return NULL;
 	}
 
 	data = mmap (NULL, st.st_size, PROT_READ, MAP_PRIVATE, handle, 0);
 	if (data == (const unsigned char *) -1) {
+	  fprintf (stderr, "MMap result %p\n", data);
 		return NULL;
 	} else {
 		*size = st.st_size;
@@ -177,6 +181,23 @@ rand_long_long (unsigned long long min, unsigned long long max)
 {
   unsigned long long delta = max - min + 1;
   return min + (unsigned long long) (delta * (rand () / (RAND_MAX + 1.0)));
+}
+
+unsigned int
+split_line_chr (const unsigned char *cdata, unsigned long long csize, const unsigned char *tokenz[], unsigned int lengths[], unsigned int max_tokens, unsigned int chr)
+{
+  unsigned int i = 0;
+  unsigned long long s = 0;
+  while ((i < max_tokens) && (cdata[s] != '\n')) {
+    unsigned long long e = s;
+    tokenz[i] = cdata + s;
+    while ((e < csize) && (cdata[e] != chr) && (cdata[e] != '\n')) e += 1;
+    lengths[i] = e - s;
+    i += 1;
+    s = e;
+    if (cdata[s] != '\n') s += 1;
+  }
+  return i;
 }
 
 unsigned int

--- a/src/utils.h
+++ b/src/utils.h
@@ -43,6 +43,7 @@ unsigned long long rand_long_long (unsigned long long min, unsigned long long ma
 /* Line ends with \n (or at csize), tokens end with \t */
 /* Return number of tokens */
 unsigned int split_line (const unsigned char *cdata, unsigned long long csize, const unsigned char *tokenz[], unsigned int lengths[], unsigned int max_tokens);
+unsigned int split_line_chr (const unsigned char *cdata, unsigned long long csize, const unsigned char *tokenz[], unsigned int lengths[], unsigned int max_tokens, unsigned int chr);
 
 /* Print number as binary with given number of digits (0 - start from leftmost 1) */
 /* Returns the length of string (not counting terminating 0) */

--- a/src/word-list-stream.c
+++ b/src/word-list-stream.c
@@ -100,7 +100,7 @@ unsigned int
 word_list_stream_get_first_word (GT4WordSArrayImplementation *impl, GT4WordSArrayInstance *inst)
 {
   GT4WordListStream *stream = GT4_WORD_LIST_STREAM_FROM_SARRAY_INSTANCE(inst);
-  lseek (stream->ifile, sizeof (GT4ListHeader), SEEK_SET);
+  lseek (stream->ifile, stream->header.list_start, SEEK_SET);
   stream->bp = 0;
   stream->bsize = 0;
   if (!stream_read (stream)) return 0;
@@ -166,6 +166,7 @@ gt4_word_list_stream_new (const char *filename, unsigned int major_version)
   stream->sarray_instance.num_words = stream->header.nwords;
   stream->sarray_instance.word_length = stream->header.wordlength;
   if (stream->sarray_instance.num_words > 0) {
+    lseek (stream->ifile, stream->header.list_start, SEEK_SET);
     if (!stream_read (stream)) {
       gt4_word_list_stream_delete (stream);
       return NULL;

--- a/src/word-list.c
+++ b/src/word-list.c
@@ -1,0 +1,27 @@
+#define __GT4_WORD_LIST_C__
+
+/*
+ * GenomeTester4
+ *
+ * A toolkit for creating and manipulating k-mer lists from biological sequences
+ * 
+ * Copyright (C) 2014-2018 University of Tartu
+ *
+ * Authors: Maarja Lepamets and Lauris Kaplinski
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+unsigned int GT4_LIST_CODE = 'G' << 24 | 'T' << 16 | '4' << 8 | 'C';
+

--- a/src/word-list.h
+++ b/src/word-list.h
@@ -1,0 +1,49 @@
+#ifndef __GT4_WORD_LIST_H__
+#define __GT4_WORD_LIST_H__
+
+/*
+ * GenomeTester4
+ *
+ * A toolkit for creating and manipulating k-mer lists from biological sequences
+ * 
+ * Copyright (C) 2014-2016 University of Tartu
+ *
+ * Authors: Maarja Lepamets and Lauris Kaplinski
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * GenomeTester4 list file format
+ */
+
+#ifndef __GT4_WORD_LIST_C__
+/* List tag "GT4C" encoded to big-endian 32-bit integer */
+extern unsigned int GT4_LIST_CODE;
+#endif
+
+typedef struct _GT4ListHeader GT4ListHeader;
+
+struct _GT4ListHeader {
+  unsigned int code;
+  unsigned int version_major;
+  unsigned int version_minor;
+  unsigned int wordlength;
+  unsigned long long nwords;
+  unsigned long long totalfreq;
+  /* Offset (from the beginning of header) of word/count data */
+  unsigned long long list_start;
+};
+
+#endif

--- a/src/word-map.c
+++ b/src/word-map.c
@@ -38,8 +38,6 @@
 
 unsigned int debug_wordmap = 0;
 
-unsigned int GT4_LIST_CODE = 'G' << 24 | 'T' << 16 | '4' << 8 | 'C';
-
 static void word_map_class_init (GT4WordMapClass *klass);
 /* AZObject implementation */
 static void word_map_shutdown (AZObject *object);
@@ -149,7 +147,7 @@ gt4_word_map_new (const char *listfilename, unsigned int major_version, unsigned
     gt4_word_map_delete (wmap);
     return NULL;
   }
-  wmap->wordlist = cdata + sizeof (GT4ListHeader);
+  wmap->wordlist = cdata + wmap->header->list_start;
   if (scout) {
     scout_mmap ((const unsigned char *) cdata, csize);
   }

--- a/src/word-map.h
+++ b/src/word-map.h
@@ -43,27 +43,15 @@ typedef struct _GT4WordMapClass GT4WordMapClass;
 extern GT4WordMapClass *gt4_word_map_class;
 /* Defaults to 0, can be increased to print debug information */
 extern unsigned int debug_wordmap;
-/* List tag "GT4C" encoded to big-endian 32-bit integer */
-extern unsigned int GT4_LIST_CODE;
 #endif
 
 #include <az/object.h>
 
+#include "word-list.h"
+
 #include "word-array-sorted.h"
 
 #define WORDMAP_ELEMENT_SIZE (sizeof (unsigned long long) + sizeof (unsigned int))
-
-typedef struct _GT4ListHeader GT4ListHeader;
-
-struct _GT4ListHeader {
-  unsigned int code;
-  unsigned int version_major;
-  unsigned int version_minor;
-  unsigned int wordlength;
-  unsigned long long nwords;
-  unsigned long long totalfreq;
-  unsigned long long padding;
-};
 
 typedef struct _parameters {
 	unsigned int wordlength;

--- a/src/wordtable.c
+++ b/src/wordtable.c
@@ -378,7 +378,7 @@ wordtable_write_to_file (wordtable *table, const char *outputname, unsigned int 
 	h.wordlength = table->wordlength;
 	h.nwords = count;
 	h.totalfreq = totalfreq;
-	h.padding = sizeof (GT4ListHeader);
+	h.list_start = sizeof (GT4ListHeader);
 	fseek (f, 0, SEEK_SET);
 	fwrite (&h, sizeof (GT4ListHeader), 1, f);
 	fclose (f);


### PR DESCRIPTION
One of the calls to `gt4_word_map_new` in `glistcompare.c` sets the `major_version` argument to `VERSION_MINOR`.

I think the correct value should be `VERSION_MAJOR`.